### PR TITLE
Add support for loading plain HTML and QML.

### DIFF
--- a/webvfx/effects_impl.cpp
+++ b/webvfx/effects_impl.cpp
@@ -122,12 +122,30 @@ void EffectsImpl::initializeInvokable(const QUrl& url, const QSize& size, Parame
     if (path.endsWith(".html", Qt::CaseInsensitive)) {
         WebContent* webContent = new WebContent(size, parameters);
         content = webContent;
-        connect(webContent, SIGNAL(contentLoadFinished(bool)), SLOT(initializeComplete(bool)));
+#ifdef WEBVFX_FILENAMEEXT
+        if (path.endsWith(".webvfx.html", Qt::CaseInsensitive)) {
+#else
+        if (!path.endsWith(".plain.html", Qt::CaseInsensitive)) {
+#endif
+            connect(webContent, SIGNAL(contentLoadFinished(bool)), SLOT(initializeComplete(bool)));
+        }
+        else {
+            connect(webContent, SIGNAL(vanillaLoadFinished(bool)), SLOT(initializeComplete(bool)));
+        }
     }
     else if (path.endsWith(".qml", Qt::CaseInsensitive)) {
         QmlContent* qmlContent = new QmlContent(size, parameters);
         content = qmlContent;
-        connect(qmlContent, SIGNAL(contentLoadFinished(bool)), SLOT(initializeComplete(bool)));
+#ifdef WEBVFX_FILENAMEEXT
+        if (path.endsWith(".webvfx.qml", Qt::CaseInsensitive)) {
+#else
+        if (!path.endsWith(".plain.qml", Qt::CaseInsensitive)) {
+#endif
+            connect(qmlContent, SIGNAL(contentLoadFinished(bool)), SLOT(initializeComplete(bool)));
+        }
+        else {
+            connect(qmlContent, SIGNAL(vanillaLoadFinished(bool)), SLOT(initializeComplete(bool)));
+        }
     }
     else {
         log(QLatin1Literal("WebVfx Filename must end with '.html' or '.qml': ") % path);

--- a/webvfx/qml_content.cpp
+++ b/webvfx/qml_content.cpp
@@ -115,6 +115,10 @@ void QmlContent::contentContextLoadFinished(bool result)
 {
     if (contextLoadFinished == LoadNotFinished)
         contextLoadFinished = result ? LoadSucceeded : LoadFailed;
+
+    // This is useful when webvfx.renderReady(true) is not used.
+    emit vanillaLoadFinished(pageLoadFinished == LoadSucceeded);
+
     if (contextLoadFinished == LoadFailed || pageLoadFinished != LoadNotFinished) {
         logWarnings(errors());
         emit contentLoadFinished(contextLoadFinished == LoadSucceeded && pageLoadFinished == LoadSucceeded);

--- a/webvfx/qml_content.h
+++ b/webvfx/qml_content.h
@@ -43,6 +43,7 @@ public:
 
 signals:
     void contentLoadFinished(bool result);
+    void vanillaLoadFinished(bool result);
 
 private slots:
     void qmlViewStatusChanged(QDeclarativeView::Status status);

--- a/webvfx/web_content.cpp
+++ b/webvfx/web_content.cpp
@@ -123,6 +123,10 @@ void WebContent::webPageLoadFinished(bool result)
 {
     if (pageLoadFinished == LoadNotFinished)
         pageLoadFinished = result ? LoadSucceeded : LoadFailed;
+
+    // This is useful when webvfx.renderReady(true) is not used.
+    emit vanillaLoadFinished(pageLoadFinished == LoadSucceeded);
+
     if (pageLoadFinished == LoadFailed || contextLoadFinished != LoadNotFinished)
         emit contentLoadFinished(contextLoadFinished == LoadSucceeded && pageLoadFinished == LoadSucceeded);
 }

--- a/webvfx/web_content.h
+++ b/webvfx/web_content.h
@@ -55,6 +55,7 @@ public:
 
 signals:
     void contentLoadFinished(bool result);
+    void vanillaLoadFinished(bool result);
 
 private slots:
     void injectContentContext();


### PR DESCRIPTION
Plain means the content does not contain a webvfx.renderReady(true)
call. The new behavior requires that the filename ends with .plain.html
or .plain.qml. There is a WEBVFX_FILENAMEEXT define that inverses the
behavior such that .html and .qml load without webvfx.renderReady(true)
and a .webvfx.html or .webvfx.qml is required to make rendering wait for
renderReady(true).
