### PR TITLE
Add support for loading plain HTML and QML.

### DIFF
--- a/webvfx/effects_impl.h
+++ b/webvfx/effects_impl.h
@@ -39,7 +39,7 @@ private slots:
 
 private:
     ~EffectsImpl();
-    Q_INVOKABLE void initializeInvokable(const QUrl& url, const QSize& size, Parameters* parameters);
+    Q_INVOKABLE void initializeInvokable(const QUrl& url, const QSize& size, Parameters* parameters, bool isPlain);
     Q_INVOKABLE void renderInvokable(double time, Image* renderImage);
 
     // Test if we are currently on the UI thread

--- a/webvfx/qml_content.cpp
+++ b/webvfx/qml_content.cpp
@@ -104,6 +104,10 @@ void QmlContent::qmlViewStatusChanged(QDeclarativeView::Status status)
 
     if (pageLoadFinished == LoadNotFinished)
         pageLoadFinished = (status == QDeclarativeView::Ready) ? LoadSucceeded : LoadFailed;
+
+    // This is useful when webvfx.renderReady(true) is not used.
+    emit contentPreLoadFinished(pageLoadFinished == LoadSucceeded);
+
     if (pageLoadFinished == LoadFailed || contextLoadFinished != LoadNotFinished) {
 
         logWarnings(errors());

--- a/webvfx/qml_content.h
+++ b/webvfx/qml_content.h
@@ -43,6 +43,7 @@ public:
 
 signals:
     void contentLoadFinished(bool result);
+    void contentPreLoadFinished(bool result);
 
 private slots:
     void qmlViewStatusChanged(QDeclarativeView::Status status);

--- a/webvfx/web_content.cpp
+++ b/webvfx/web_content.cpp
@@ -123,6 +123,10 @@ void WebContent::webPageLoadFinished(bool result)
 {
     if (pageLoadFinished == LoadNotFinished)
         pageLoadFinished = result ? LoadSucceeded : LoadFailed;
+
+    // This is useful when webvfx.renderReady(true) is not used.
+    emit contentPreLoadFinished(pageLoadFinished == LoadSucceeded);
+
     if (pageLoadFinished == LoadFailed || contextLoadFinished != LoadNotFinished)
         emit contentLoadFinished(contextLoadFinished == LoadSucceeded && pageLoadFinished == LoadSucceeded);
 }

--- a/webvfx/web_content.h
+++ b/webvfx/web_content.h
@@ -55,6 +55,7 @@ public:
 
 signals:
     void contentLoadFinished(bool result);
+    void contentPreLoadFinished(bool result);
 
 private slots:
     void injectContentContext();


### PR DESCRIPTION
Plain means the content does not contain a webvfx.renderReady(true)
call. The new behavior requires that the filename ends with .plain.html
or .plain.qml. There is a WEBVFX_FILENAMEEXT define that inverses the
behavior such that .html and .qml load without webvfx.renderReady(true)
and a .webvfx.html or .webvfx.qml is required to make rendering wait for
renderReady(true).
