### PR TITLE
Make the background of plain web content transparent.

### DIFF
--- a/webvfx/effects_impl.cpp
+++ b/webvfx/effects_impl.cpp
@@ -130,6 +130,7 @@ void EffectsImpl::initializeInvokable(const QUrl& url, const QSize& size, Parame
         WebContent* webContent = new WebContent(size, parameters);
         content = webContent;
         if (isPlain) {
+            webContent->setTransparent();
             connect(webContent, SIGNAL(contentPreLoadFinished(bool)), SLOT(initializeComplete(bool)));
         }
         else {

--- a/webvfx/web_content.cpp
+++ b/webvfx/web_content.cpp
@@ -190,4 +190,13 @@ QWebSettings* WebContent::settings()
     return webPage->settings();
 }
 
+void WebContent::setTransparent()
+{
+    if (webPage) {
+        QPalette pal = webPage->palette();
+        pal.setBrush(QPalette::Base, Qt::transparent);
+        webPage->setPalette(pal);
+    }
+}
+
 }

--- a/webvfx/web_content.h
+++ b/webvfx/web_content.h
@@ -53,6 +53,8 @@ public:
     // For debugging with Viewer
     QWebSettings* settings();
 
+    void setTransparent();
+
 signals:
     void contentLoadFinished(bool result);
     void contentPreLoadFinished(bool result);


### PR DESCRIPTION
I made it so this only takes effect if you are using plain content. I guess the assumption is that if you are using the webvfx javascript extension, you have more control over the placement of the image, especially z-order. Also, it neatly avoids regressive behavior on any existing html webvfx filters and transitions.

This is already useful with the MLT filter as-is and allows HTML with no
explicit background color and no WebVfx JavaScript extensions to simply
overlay the MLT video.
