### PR TITLE
Build changes I needed for Shotcut on Windows

### DIFF
--- a/all.pro
+++ b/all.pro
@@ -15,7 +15,7 @@ SUBDIRS += viewer
 SUBDIRS += tools/render
 SUBDIRS += tools/browser
 
-unix:system(pkg-config --exists mlt-framework) {
+system(pkg-config --exists mlt-framework) {
     SUBDIRS += mlt
     mlt.depends = webvfx
     isEmpty(MLT_SOURCE) {

--- a/mlt/mlt.pro
+++ b/mlt/mlt.pro
@@ -26,6 +26,11 @@ TARGET = mltwebvfx
 
 LIBS += -L$$DESTDIR -lwebvfx
 
+win32 {
+    QT += webkit opengl declarative
+    LIBS += -lglu32 -lopengl32 -lpthread
+}
+
 QMAKE_RPATHDIR += $$PREFIX/lib
 
 # Install in mlt plugins directory

--- a/mlt/mlt.pro
+++ b/mlt/mlt.pro
@@ -19,20 +19,17 @@ SOURCES += webvfx_transition.cpp
 
 CONFIG += plugin shared
 
-unix {
-    CONFIG += link_pkgconfig
-    PKGCONFIG += mlt-framework
-}
+CONFIG += link_pkgconfig
+PKGCONFIG += mlt-framework
 
 TARGET = mltwebvfx
+
 LIBS += -L$$DESTDIR -lwebvfx
 
 QMAKE_RPATHDIR += $$PREFIX/lib
 
-unix {
-    # Install in mlt plugins directory
-    target.path = $$system(pkg-config --variable=libdir mlt-framework)/mlt
-    INSTALLS += target
-    # Add mlt plugins to rpath so we can dlopen ourself without a full path.
-    QMAKE_RPATHDIR += $$target.path
-}
+# Install in mlt plugins directory
+target.path = $$system(pkg-config --variable=libdir mlt-framework)/mlt
+INSTALLS += target
+# Add mlt plugins to rpath so we can dlopen ourself without a full path.
+QMAKE_RPATHDIR += $$target.path

--- a/mlt/qmelt/qmelt.pro
+++ b/mlt/qmelt/qmelt.pro
@@ -15,9 +15,13 @@ DEFINES += VERSION=\\\"qmelt\\\"
 INCLUDEPATH += $$MLT_SOURCE
 
 CONFIG -= app_bundle
-unix {
-    CONFIG += link_pkgconfig
-    PKGCONFIG += mlt-framework
+
+CONFIG += link_pkgconfig
+PKGCONFIG += mlt-framework
+
+win32 {
+    CONFIG += console
+    DEFINES += MELT_NOSDL
 }
 
 TARGET = qmelt

--- a/webvfx/webvfx.cpp
+++ b/webvfx/webvfx.cpp
@@ -2,14 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef Q_WS_MAC
-#include <pthread.h>
-#ifdef WEBVFX_IGNORE_SEGV
-#include <signal.h>
-#include <termios.h>
-#include <unistd.h>
-#endif
-#endif
 #include <cstdlib>
 #include <QApplication>
 #include <QMetaType>
@@ -24,6 +16,14 @@
 
 #ifndef Q_WS_WIN
 #define WEBVFX_IGNORE_SEGV
+#endif
+#ifndef Q_WS_MAC
+#include <pthread.h>
+#ifdef WEBVFX_IGNORE_SEGV
+#include <signal.h>
+#include <termios.h>
+#include <unistd.h>
+#endif
 #endif
 
 namespace WebVfx

--- a/webvfx/webvfx.cpp
+++ b/webvfx/webvfx.cpp
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#define WEBVFX_IGNORE_SEGV
-
 #ifndef Q_WS_MAC
 #include <pthread.h>
 #ifdef WEBVFX_IGNORE_SEGV
@@ -24,6 +22,9 @@
 #include "webvfx/webvfx.h"
 #include "webvfx/effects_impl.h"
 
+#ifndef Q_WS_WIN
+#define WEBVFX_IGNORE_SEGV
+#endif
 
 namespace WebVfx
 {

--- a/webvfx/webvfx.pro
+++ b/webvfx/webvfx.pro
@@ -35,7 +35,9 @@ RESOURCES += resources/resources.qrc
 
 macx:LIBS += -framework Foundation
 
-CONFIG += shared thread
+win32:CONFIG += staticlib
+unix:CONFIG += shared thread
+
 QT += webkit opengl declarative
 
 TARGET = webvfx


### PR DESCRIPTION
I am now successfully making nightly builds of Shotcut with WebVfx using my fork. These are some build-only things I needed for Windows. I think you might want to skip the commit "Shotcut-specific static build of libwebvfx on Windows." I ran into some problem with webvfx.dll and libstdc++ that I banged my head against for a couple of days. So, I ended up just statically compiling webvfx and linking mltwebvfx.dll against that.

P.S. I am looking at reusing the Qt labs htmleditor as a titler in Shotcut with superscrollorama for animation.
